### PR TITLE
Time input prettification 

### DIFF
--- a/material/templates/material/fields/django_splitdatetimewidget.html
+++ b/material/templates/material/fields/django_splitdatetimewidget.html
@@ -42,7 +42,7 @@
                {% if form_with_placeholder %}placeholder="{{ bound_field.label }}"{% endif %}
                id="id_{{ bound_field.html_name }}_1"
                data-date-format="{{ field.fields.1|jquery_datepicker_format }}"
-               data-form-control="time"{% endtagattrs %}{% if bound_field.value %} value="{{ bound_field|multiwidget_value:1|datepicker_value:field.fields.1.input_formats.0 }}"{% endif %}>
+               data-form-control="time"{% endtagattrs %}{% if bound_field.value %} value="{{ bound_field|multiwidget_value:1|datepicker_value:field.fields.1.input_formats.2 }}"{% endif %}>
     </div>
 </div>
 

--- a/material/templates/material/fields/django_timeinput.html
+++ b/material/templates/material/fields/django_timeinput.html
@@ -1,0 +1,33 @@
+{% load material_form material_form_internal %}
+<div class="row">
+    <div {% tagattrs %}
+         id="id_{{ bound_field.html_name }}_container"
+         class="{% part field group_class %}input-field col s12
+                {% if field.required%}required{% endif %}
+                {% if bound_field.errors %}has-error{% endif %}
+                {% part field add_group_class %}{% endpart %}
+                {% endpart %}"{% endtagattrs %}>
+        {% part field prefix %}{% endpart %}{% part field control %}
+        <input {% tagattrs %}
+               type="{{ field.widget.input_type }}"
+               class="{% if field.widget.attrs.class %}{{ field.widget.attrs.class }} {% endif %}{% if bound_field.errors %}invalid {% endif %}{% part field add_control_class %}{{ form_control_class }}{% endpart %}"
+               name="{{ bound_field.html_name }}"
+               {% for name, value in field.widget.attrs.items %}{% if name != 'class' %}{{name}}="{{value}}" {% endif %}{% endfor %}
+               id="id_{{ bound_field.html_name }}"
+               data-date-format="{{ field|jquery_datepicker_format }}"
+               autocomplete="false"
+               data-form-control="time"{% endtagattrs %}{% if bound_field.value %} value="{{ bound_field.value|datepicker_value:field.input_formats.2 }}"{% endif %}>
+        {% endpart %}{% part field label %}
+        <label {% tagattrs %}
+               for="{{ bound_field.id_for_label }}"
+               class="{% part field add_label_class %}{{ form_label_class }}{% endpart %}"
+               {% endtagattrs %}>{{ bound_field.label }}</label>
+        {% endpart %}{% part field help_text %}{% if field.help_text %}
+        <small class="help-block">{{ bound_field.help_text }}</small>
+        {% endif %}
+        {% endpart %}{% part field errors %}
+        {% if bound_field.errors %}
+            {% include  'material/field_errors.html' %}
+        {% endif %}{% endpart %}{{ hidden_initial }}
+    </div>
+</div>

--- a/material/templatetags/material_form_internal.py
+++ b/material/templatetags/material_form_internal.py
@@ -88,7 +88,7 @@ def multiwidget_value(bound_field, pos):
 
 @register.filter
 def jquery_datepicker_format(field):
-    input_format = field.input_formats[0]
+    input_format = field.input_formats[2]
 
     # %a, %A, %z, %f %Z %j %U %W %c %x %X unsupported
 


### PR DESCRIPTION
Two tiny patches that enhance user experience a little bit

It basically solves at least two problems, one of which caused an ugly bug:

1. Lack of TimeField input, which resulted in it being rendered as plain text, causing bugs on some locales (e.g.: en-us)
2. There is no adequate way to edit seconds in DateTime field and that actually frustrates people 

I added a pretty descriptive commit messages with details: why the commit was necessary and what has been done. 