### PR TITLE
Add support for custom admin site import instead of default django one.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -263,6 +263,12 @@ Ensure that `django.template.context_processors.request` in your template contex
         },
     ]
 
+You can provide a custom admin site module in the `MATERIAL_ADMIN_SITE` setting
+
+.. code-block:: python
+
+    MATERIAL_ADMIN_SITE = 'mymodule.admin.admin_site'
+
 Admin support development is on initial stage. Only basic admin features are available.
 
 ****

--- a/material/admin/templatetags/material_admin.py
+++ b/material/admin/templatetags/material_admin.py
@@ -1,9 +1,10 @@
 import datetime
+from importlib import import_module
 
 from django.apps import apps
 from django.contrib.admin.views.main import PAGE_VAR
-from django.contrib.admin import site
 from django.core.urlresolvers import reverse, NoReverseMatch
+from django.conf import settings
 from django.db import models
 from django.utils import formats, six
 from django.utils.dates import MONTHS
@@ -17,6 +18,20 @@ from material import Layout, Fieldset, Row
 from ..base import AdminReadonlyField
 
 register = Library()
+
+
+def get_admin_site():
+    site_module = getattr(
+        settings,
+        'MATERIAL_ADMIN_SITE',
+        'django.contrib.admin.site'
+    )
+    mod, inst = site_module.rsplit('.', 1)
+    mod = import_module(mod)
+    return getattr(mod, inst)
+
+
+site = get_admin_site()
 
 
 @register.assignment_tag


### PR DESCRIPTION
An additional option for custom admin site object. 
It's a first step that can allow basic customization for users with custom admin site. Another solution could be to get inspiration from grappelli dashboard customization module. 
Default is the current behavior : using django admin site object.
I also updated the doc to mention this new option but I don't know if it's the right place.
 