### PR TITLE
Fixes issue viewflow/django-material#12 .

### DIFF
--- a/material/admin/static/admin/js/related-widget-wrapper.js
+++ b/material/admin/static/admin/js/related-widget-wrapper.js
@@ -1,0 +1,25 @@
+django.jQuery(function($){
+    function updateLinks() {
+        var $this = $(this);
+        var siblings = $this.closest('.related-widget-wrapper > .col').nextAll('.change-related, .delete-related');
+        if (!siblings.length) return;
+        var value = $this.val();
+        if (value) {
+            siblings.each(function(){
+                var elm = $(this);
+                elm.attr('href', elm.attr('data-href-template').replace('__fk__', value));
+            });
+        } else siblings.removeAttr('href');
+    }
+    var container = $(document);
+    container.on('change', '.related-widget-wrapper select', updateLinks);
+    // Materialize use its own jquery declared in global scope. Listen on it.
+    jQuery('.related-widget-wrapper select').on('change', updateLinks);
+    container.find('.related-widget-wrapper select').each(updateLinks);
+    container.on('click', '.related-widget-wrapper-link', function(event){
+        if (this.href) {
+            showRelatedObjectPopup(this);
+        }
+        event.preventDefault();
+    });
+});

--- a/material/admin/templates/admin/related_widget_wrapper.html
+++ b/material/admin/templates/admin/related_widget_wrapper.html
@@ -1,0 +1,29 @@
+{% load i18n admin_static %}
+<div class="related-widget-wrapper">
+    <div class="col s10">
+        {{ widget }}
+    </div>
+    {% block links %}
+        {% if can_change_related %}
+        <a class="related-widget-wrapper-link change-related" id="change_id_{{ name }}"
+            data-href-template="{{ change_related_template_url }}?{{ url_params }}"
+            title="{% blocktrans %}Change selected {{ model }}{% endblocktrans %}">
+            <i class="mdi-editor-mode-edit"></i>
+        </a>
+        {% endif %}
+        {% if can_add_related %}
+        <a class="related-widget-wrapper-link add-related" id="add_id_{{ name }}"
+            href="{{ add_related_url }}?{{ url_params }}"
+            title="{% blocktrans %}Add another {{ model }}{% endblocktrans %}">
+            <i class="mdi-content-add"></i>
+        </a>
+        {% endif %}
+        {% if can_delete_related %}
+        <a class="related-widget-wrapper-link delete-related" id="delete_id_{{ name }}"
+            data-href-template="{{ delete_related_template_url }}?{{ url_params }}"
+            title="{% blocktrans %}Delete selected {{ model }}{% endblocktrans %}">
+            <i class="mdi-action-delete"></i>
+        </a>
+        {% endif %}
+    {% endblock %}
+</div>

--- a/material/admin/templates/material/fields/django_relatedfieldwidgetwrapper.html
+++ b/material/admin/templates/material/fields/django_relatedfieldwidgetwrapper.html
@@ -1,13 +1,8 @@
 {% load material_form material_form_internal %}
 
-{% render bound_field widget=field.widget.widget %}
-    {% part field label %}
-    <h6 for="{{ bound_field.id_for_label }}" class="{% part field add_label_class %}{{ form_label_class }}{% endpart %}">
-        {{ bound_field.label }}
-        <a href="%s%s" class="add-another" id="add_id_{{ bound_field.html_name }}" onclick="return showAddAnotherPopup(this);">
-            <i class="mdi-content-add"></i>
-        </a>
-    </h6>
-    {% endpart %}
-    {% part field help_text %}{% endpart%}
-{% endrender %}
+<div class="row">
+<label for="{{ bound_field.id_for_label }}" class="col s12 {% part field add_label_class %}{{ form_label_class }}{% endpart %}">
+    {{ bound_field.label }}
+</label>
+{{ bound_field }}
+</div>


### PR DESCRIPTION
Use django rendering for bound field and customize only template as advised by @kmmbvnr.
Hopefully I understood correctly the advised way to fix it :).

There is maybe a better way to layout the col/row wrapper. This way gives a good rendering layout for add/edit/delete buttons but is maybe not perfect as it involves to levels of row/col divs. Let me know if you see a better solution.

Also had to modify the django javascript to update add/modify/delete links since materialize use a jquery different from the django one (and does not share events registry).
