### PR TITLE
First working implem for issue viewflow/django-material#1.

### DIFF
--- a/material/admin/static/material/admin/css/base.css
+++ b/material/admin/static/material/admin/css/base.css
@@ -71,6 +71,10 @@ body {
     .card-content {
         padding: 15px;
     }
+    
+    .card-section {
+        padding: 5px 15px;
+    }
 
     main>.row>.col {
         padding: 0;
@@ -405,6 +409,23 @@ ul.side-nav.module-menu li.active>a>span.badge {
     color: #F44336;
 }
 
+.change-form .card-section {
+    background-color: #F4F4F4;
+    border-top: 1px solid rgba(160, 160, 160, 0.2);
+}
+
+.change-form .card-section fieldset {
+    border-width: 0px;
+}
+
+.change-form fieldset .empty-form {
+    display: none;
+}
+
+.change-form fieldset .select-wrapper input.select-dropdown {
+    margin-top: 0;
+}
+
 @media only screen and (min-width : 601px) {
     .change-form .multiselect {
         margin-bottom:40px;
@@ -465,5 +486,8 @@ ul.side-nav.module-menu li.active>a>span.badge {
 @media only screen and (min-width : 992px) {
     .change-form .card .card-content {
         padding: 30px 50px 50px 50px;
+    }
+    .change-form .card .card-section {
+        padding: 10px 50px 10px 50px;
     }
 }

--- a/material/admin/templates/admin/change_form.html
+++ b/material/admin/templates/admin/change_form.html
@@ -49,13 +49,7 @@
                             {% endblock %}
                             
                             {% block after_field_sets %}{% endblock %}
-                            
-                            {% block inline_field_sets %}
-                            {% for inline_admin_formset in inline_admin_formsets %}
-                            {% include inline_admin_formset.opts.template %}
-                            {% endfor %}
-                            {% endblock %}
-                            
+
                             {% block after_related_objects %}{% endblock %}
                             
                             {% block submit_buttons_bottom %}{% submit_row %}{% endblock %}
@@ -64,6 +58,12 @@
                     {# JavaScript for prepopulated fields #}
                     {% prepopulated_fields_js %}
                 </div>
+
+                {% block inline_field_sets %}
+                {% for inline_admin_formset in inline_admin_formsets %}
+                {% include inline_admin_formset.opts.template %}
+                {% endfor %}
+                {% endblock %}
                 <div class="card-action">
                     <div class="right-align">
                         {% submit_row %}

--- a/material/admin/templates/admin/edit_inline/tabular.html
+++ b/material/admin/templates/admin/edit_inline/tabular.html
@@ -1,0 +1,106 @@
+{% load i18n admin_urls admin_static admin_modify %}
+<div class="inline-group card-content card-section" id="{{ inline_admin_formset.formset.prefix }}-group">
+  <div class="tabular inline-related {% if forloop.last %}last-related{% endif %}">
+{{ inline_admin_formset.formset.management_form }}
+<fieldset class="module row section">
+   <h5>{{ inline_admin_formset.opts.verbose_name_plural|capfirst }}</h5>
+   {{ inline_admin_formset.formset.non_form_errors }}
+   <table>
+     <thead><tr>
+     {% for field in inline_admin_formset.fields %}
+       {% if not field.widget.is_hidden %}
+         <th{% if field.required %} class="required"{% endif %}>{{ field.label|capfirst }}
+         {% if field.help_text %}&nbsp;<img src="{% static "admin/img/icon-unknown.gif" %}" class="help help-tooltip" width="10" height="10" alt="({{ field.help_text|striptags }})" title="{{ field.help_text|striptags }}" />{% endif %}
+         </th>
+       {% endif %}
+     {% endfor %}
+     {% if inline_admin_formset.formset.can_delete %}<th>{% trans "Delete?" %}</th>{% endif %}
+     </tr></thead>
+
+     <tbody>
+     {% for inline_admin_form in inline_admin_formset %}
+        {% if inline_admin_form.form.non_field_errors %}
+        <tr><td colspan="{{ inline_admin_form|cell_count }}">{{ inline_admin_form.form.non_field_errors }}</td></tr>
+        {% endif %}
+        <tr class="form-row {% cycle "row1" "row2" %} {% if inline_admin_form.original or inline_admin_form.show_url %}has_original{% endif %}{% if forloop.last %} empty-form{% endif %}"
+             id="{{ inline_admin_formset.formset.prefix }}-{% if not forloop.last %}{{ forloop.counter0 }}{% else %}empty{% endif %}">
+        <td class="original" style="display:none;">
+          {% if inline_admin_form.original or inline_admin_form.show_url %}<p>
+          {% if inline_admin_form.original %}
+          {{ inline_admin_form.original }}
+          {% if inline_admin_form.model_admin.show_change_link and inline_admin_form.model_admin.has_registered_model %}<a href="{% url inline_admin_form.model_admin.opts|admin_urlname:'change' inline_admin_form.original.pk|admin_urlquote %}" class="inlinechangelink">{% trans "Change" %}</a>{% endif %}
+          {% endif %}
+          {% if inline_admin_form.show_url %}<a href="{{ inline_admin_form.absolute_url }}">{% trans "View on site" %}</a>{% endif %}
+            </p>{% endif %}
+          {% if inline_admin_form.needs_explicit_pk_field %}{{ inline_admin_form.pk_field.field }}{% endif %}
+          {{ inline_admin_form.fk_field.field }}
+          {% spaceless %}
+          {% for fieldset in inline_admin_form %}
+            {% for line in fieldset %}
+              {% for field in line %}
+                {% if field.field.is_hidden %} {{ field.field }} {% endif %}
+              {% endfor %}
+            {% endfor %}
+          {% endfor %}
+          {% endspaceless %}
+        </td>
+        {% for fieldset in inline_admin_form %}
+          {% for line in fieldset %}
+            {% for field in line %}
+              {% if not field.field.is_hidden %}
+              <td{% if field.field.name %} class="field-{{ field.field.name }}"{% endif %}>
+              {% if field.is_readonly %}
+                  <p>{{ field.contents }}</p>
+              {% else %}
+                  {{ field.field.errors.as_ul }}
+                  {{ field.field }}
+              {% endif %}
+              </td>
+              {% endif %}
+            {% endfor %}
+          {% endfor %}
+        {% endfor %}
+        {% if inline_admin_formset.formset.can_delete %}
+          <td class="delete">{% if inline_admin_form.original %}{{ inline_admin_form.deletion_field.field }}{% endif %}</td>
+        {% endif %}
+        </tr>
+     {% endfor %}
+     </tbody>
+   </table>
+</fieldset>
+  </div>
+</div>
+
+<script type="text/javascript">
+
+(function($) {
+  var tabFormset = $("#{{ inline_admin_formset.formset.prefix|escapejs }}-group .tabular.inline-related tbody tr");
+  tabFormset.tabularFormset({
+    prefix: "{{ inline_admin_formset.formset.prefix|escapejs }}",
+    addText: "{% filter escapejs %}{% blocktrans with inline_admin_formset.opts.verbose_name|capfirst as verbose_name %}Add another {{ verbose_name }}{% endblocktrans %}{% endfilter %}",
+    deleteText: "{% filter escapejs %}<i class='mdi-action-delete'></i>{% endfilter %}"
+  });
+
+  /* Material look for delete button */
+  $("#{{ inline_admin_formset.formset.prefix|escapejs }}-group .tabular td.delete input[type='checkbox']").each(function(){
+     var $chkbox = $(this);
+     var $btn = $('<i class="mdi-action-delete" style="cursor:pointer;"></i>')
+                  .on("click", function(){
+           $chkbox.attr("checked", "true");
+           $chkbox.closest("tr").hide();
+     });
+     $chkbox.after($btn);
+  });
+  
+  /* Materialize all select added in fieldset except the empty set one*/
+  var addButton = tabFormset.filter(":last").next().find("a");
+  addButton.on("click", function(){
+       var nselects = window.jQuery("tr:not(.empty-form) select", addButton.closest("table").get(0));
+       nselects.removeClass("browser-default");
+       nselects.material_select("destroy");
+       nselects.material_select();
+  });
+  $("#{{ inline_admin_formset.formset.prefix|escapejs }}-group .tabular .empty-form select").addClass("browser-default");
+
+})(django.jQuery);
+</script>


### PR DESCRIPTION
Adds only tabular support for now.
Supports material_select form fields in inline form.

Feel free to pull this if you think it helps. It should improves things since it restores save feature in case user have an inline edit. 
However I didn't test all possible inline form fields cases (only the ones on my project). So if somebody else did a better contrib (I've seen some people working on it in issue list), maybe their contrib should probably override this one.

BTW, I forgot to thank you for the project in my first pull request ;). It's an awesome project and saved me a lot of time :). 
Also let me know if you prefer a different way to contribute / or add reference / information in pull requests. I try to branch as much as possible for each single feature/fix so that you can integrate only pull requests you think useful for core project; but if you prefer a single bigger pull request to merge all changes at once let me know.
