### PR TITLE
Fix select multiple. Force everythingh to string.

### DIFF
--- a/material/templates/material/fields/django_selectmultiple.html
+++ b/material/templates/material/fields/django_selectmultiple.html
@@ -8,7 +8,7 @@
              <option value="" disabled selected>Choose your option</option>
         {% endif %}
         {% for value, choice in field.widget.choices %}
-        <option {% if value|force_text in bound_field.value %}selected="selected"{% endif %}
+        <option {% if value|force_text in bound_field.value|elements_to_text %}selected="selected"{% endif %}
                 {% if value == None or value == '' %}style="display:none"{% endif %}
                 value="{{ value|default_if_none:"" }}" >{% if value == None or value == '' %}{{ form_select_empty_label|default:choice }}{% else %}{{ choice }}{% endif %} </option>
         {% endfor %}

--- a/material/templatetags/material_form_internal.py
+++ b/material/templatetags/material_form_internal.py
@@ -133,6 +133,17 @@ def force_text_impl(value):
     return force_text(value)
 
 
+@register.filter('elements_to_text')
+def force_elements_to_text(value):
+    if isinstance(value, list):
+        new_list = []
+        for e in value:
+            new_list.append(force_text(e))
+        return new_list
+    else:
+        return force_text(value)
+
+
 @register.filter
 def split_choices_by_columns(choices, columns):
     columns = int(columns)


### PR DESCRIPTION
Man, the problem was bigger. Now everything is forced to string, is slow...but works. I believe this solution is better,  because is more secure. Other solution is force entire list to string and not element by element. 

I believe that [here](https://github.com/viewflow/django-material/blob/master/material/admin/templates/material/fields/django_filteredselectmultiple.html#L9) and [here](https://github.com/viewflow/django-material/blob/master/material/templates/material/fields/django_checkboxselectmultiple.html#L27)  we have the same problem.