### PR TITLE
Fix misuse of 'static' template tags.

### DIFF
--- a/material/templates/material/includes/material_css.html
+++ b/material/templates/material/includes/material_css.html
@@ -1,4 +1,4 @@
-{% load static %}
+{% load admin_static %}
 <link href="{% static 'material/css/materialize.css' %}" rel="stylesheet">
 <link href="{% static 'material/css/jquery.datetimepicker.css ' %}" rel="stylesheet">
 <link href="{% static 'material/css/forms.css ' %}" rel="stylesheet">

--- a/material/templates/material/includes/material_js.html
+++ b/material/templates/material/includes/material_js.html
@@ -1,4 +1,4 @@
-{% load static i18n %}
+{% load admin_static i18n %}
 {% get_current_language as LANGUAGE_CODE %}
 {% get_language_info for LANGUAGE_CODE as lang %}
 <script src="{% static 'material/js/jquery.datetimepicker.js' %}"></script>


### PR DESCRIPTION
From the [Django's documentation](https://docs.djangoproject.com/en/1.8/ref/templates/builtins/#static) is indicated to not use the builtin ``static`` templatetags since it  generates the path without taking into consideration the storage class.

In my case we are using the storage over ``S3`` and the static assets are not loaded.