### PR TITLE
Included jQuery in form-docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,11 +53,12 @@ Add `material` into INSTALLED_APPS settings
          ...
     )
 
-Include material javascript and styles into your base template.
+Include material javascript and styles along with jQuery into your base template.
 
 .. code-block:: html
 
     {% include 'material/includes/material_css.html' %}
+    <script src="https://code.jquery.com/jquery-2.1.1.min.js"></script>
     {% include 'material/includes/material_js.html' %}
 
 Load the `material_form` template tag library


### PR DESCRIPTION
Well, I was using it with forms and the fields were not working as I expected with Materialize. Took me hours to realize that this needed jQuery and it was not included in the documentation.

I hope this would save time to other people.