### PR TITLE
added sorting in admin change_list by clicking on headers

### DIFF
--- a/material/admin/templates/admin/change_list_results.html
+++ b/material/admin/templates/admin/change_list_results.html
@@ -8,7 +8,17 @@
                 {% for header in result_headers %}
                 {% if 'action-checkbox' not in header.class_attrib %}
                 <th scope="col" {{ header.class_attrib }}>
-                    {{ header.text|capfirst }}
+                    {% if header.sortable %}
+                        {% if header.sort_priority == 0 %}
+                            <a href="{{ header.url_primary }}">{{ header.text|capfirst }}</a>
+                        {% elif header.ascending %}
+                            <a href="{{ header.url_primary }}" title="{% trans "Toggle sorting" %}">{{ header.text|capfirst }}</a>&nbsp;<i class="zmdi zmdi-chevron-up"></i>
+                        {% else %}
+                            <a href="{{ header.url_remove }}" title="{% trans "Remove from sorting" %}">{{ header.text|capfirst }}</a>&nbsp;<i class="zmdi zmdi-chevron-down"></i>
+                        {% endif %}
+                    {% else %}
+                        <span>{{ header.text|capfirst }}</span>
+                    {% endif %}
                 </th>{% endif %}{% endfor %}
             </tr>
         </thead>

--- a/material/admin/templates/admin/change_list_results.html
+++ b/material/admin/templates/admin/change_list_results.html
@@ -12,9 +12,9 @@
                         {% if header.sort_priority == 0 %}
                             <a href="{{ header.url_primary }}">{{ header.text|capfirst }}</a>
                         {% elif header.ascending %}
-                            <a href="{{ header.url_primary }}" title="{% trans "Toggle sorting" %}">{{ header.text|capfirst }}</a>&nbsp;<i class="zmdi zmdi-chevron-up"></i>
+                            <a href="{{ header.url_primary }}" title="{% trans "Toggle sorting" %}">{{ header.text|capfirst }}</a>&nbsp;∧
                         {% else %}
-                            <a href="{{ header.url_remove }}" title="{% trans "Remove from sorting" %}">{{ header.text|capfirst }}</a>&nbsp;<i class="zmdi zmdi-chevron-down"></i>
+                            <a href="{{ header.url_remove }}" title="{% trans "Remove from sorting" %}">{{ header.text|capfirst }}</a>&nbsp;∨
                         {% endif %}
                     {% else %}
                         <span>{{ header.text|capfirst }}</span>


### PR DESCRIPTION
Hi,

This PR adds sorting to the admin change_list by clicking on headers, partially fixing #106

The implementation is simpler than in Django's native admin list, as this doesn't display the ordering priorities in case the user sorts by multiple columns.

Hope you like it !

Olivier



![capture d ecran 2016-04-16 12 29 11](https://cloud.githubusercontent.com/assets/1894106/14580951/043ed320-03cf-11e6-9c1a-2b1079557f66.png)