### PR TITLE
admin filters improvements

### DIFF
--- a/material/admin/static/material/admin/css/base.css
+++ b/material/admin/static/material/admin/css/base.css
@@ -257,6 +257,12 @@ ul.side-nav.module-menu li.active>a>span.badge {
 /*
     Change list page
 */
+
+.filter-toggle {
+    position: absolute;
+    top: 5px;
+    right: 5px;
+}
 .filters a {
     margin-right: 0;
 }

--- a/material/admin/templates/admin/change_list.html
+++ b/material/admin/templates/admin/change_list.html
@@ -44,9 +44,52 @@
 
 {% block content %}
 <div class="row">
-    <div class="col s12 {% if cl.date_hierarchy or cl.list_filter or cl.search_fields %}m8 l9{% else %}m12 l12{% endif %}">
+
+    {% if cl.date_hierarchy or cl.list_filter or cl.search_fields %}
+    <div class="col s12{% if not cl.preserved_filters %} hide{% endif %}" id="filters_block">
+        <div class="card filters">
+            <div class="card-content">
+
+                <a class="filter-toggle btn-floating btn-small waves-effect waves-light green{% if not cl.preserved_filters %} lighten-4{% endif %} z-depth-0" src="#" onclick="$('#filters_block').addClass('hide'); $('#filters_toggle').removeClass('hide');">
+                    <i class="large zmdi zmdi-filter-list"></i>
+                </a>
+                <span class="card-title black-text" style="margin-bottom:20px">{% trans 'Filters' %}</span>
+                    
+                <div class="row">
+
+                    <div class="col s12 m6">
+                        {% block search %}{% search_form cl %}{% endblock %}
+                    </div>                    
+
+                    <div class="col s12 m6">
+                        {% block date_hierarchy %}{% date_hierarchy cl %}{% endblock %}
+                    </div>
+
+                    {% block filters %}
+                    {% if cl.has_filters %}
+                    {% for spec in cl.filter_specs %}
+                    <div id="changelist-filter" class="col s6 m4 l3">
+                        {% admin_list_filter cl spec %}
+                    </div>
+                    {% endfor %}
+                    {% endif %}
+                    {% endblock %}
+
+                </div>
+            </div>
+        </div>
+    </div>
+    {% endif %}
+
+    <div class="col s12">
         <div class="card data-card">
             <div class="card-content">
+                {% if cl.date_hierarchy or cl.list_filter or cl.search_fields %}
+                <a title="{% trans 'Filters' %}" id="filters_toggle" class="filter-toggle btn-floating btn-small waves-effect waves-light green{% if not cl.preserved_filters %} lighten-4{% endif %} z-depth-0{% if cl.preserved_filters %} hide{% endif %}" src="#" onclick="$('#filters_block').removeClass('hide'); $('#filters_toggle').addClass('hide');">
+                    <i class="large zmdi zmdi-filter-list"></i>
+                </a>
+                {% endif %}
+
                 {% block result_list %}
                 {% result_list cl %}
                 {% endblock %}
@@ -55,28 +98,6 @@
             </div>
         </div>
     </div>
-    {% if cl.date_hierarchy or cl.list_filter or cl.search_fields %}
-    <div class="col s12 m4 l3">
-        <div class="card filters">
-            <div class="card-content">
-                <span class="card-title black-text" style="margin-bottom:20px">{% trans 'Filters' %}</span>
-                {% block search %}{% search_form cl %}{% endblock %}
-
-                {% block filters %}
-                {% if cl.has_filters %}
-                <div id="changelist-filter row">
-                    {% for spec in cl.filter_specs %}{% admin_list_filter cl spec %}{% endfor %}
-                </div>
-                {% endif %}
-                {% endblock %}
-
-                {% block date_hierarchy %}{% date_hierarchy cl %}{% endblock %}
-                <div class="clearfix"></div>
-            </div>
-            <div class="card-action">&nbsp;</div>
-        </div>
-    </div>
-    {% endif %}
 
     {% if has_add_permission %}
     {% url cl.opts|admin_urlname:'add' as add_url %}

--- a/material/admin/templates/admin/pagination.html
+++ b/material/admin/templates/admin/pagination.html
@@ -18,7 +18,8 @@
             <div class="right">
                 <small>
                     {{ cl.result_count }} {% ifequal cl.result_count 1 %}{{ cl.opts.verbose_name }}{% else %}{{ cl.opts.verbose_name_plural }}{% endifequal %}
-                    {% if show_all_url %}&nbsp;&nbsp;<a href="{{ show_all_url }}" class="showall">{% trans 'Show all' %}</a>{% endif %}
+                    
+                    (<a href="?{% if cl.is_popup %}_popup=1{% endif %}">{% blocktrans with full_result_count=cl.full_result_count %}{{ full_result_count }} total{% endblocktrans %}</a>)
                 </small>
             </div>
         </div>

--- a/material/admin/templates/admin/search_form.html
+++ b/material/admin/templates/admin/search_form.html
@@ -1,15 +1,10 @@
 {% load i18n admin_static %}
 {% if cl.search_fields %}
-<div class="row">
+<div class="input-field col s12">
     <form id="changelist-search" action="" method="get">
-        <div class="input-field col s12">
-            <input type="text" name="{{ search_var }}" value="{{ cl.query }}" id="searchbar"/>
-            <label for="searchbar" class="{% if cl.query %}active{% endif %}">{% trans 'Search' %} {{ cl.opts.verbose_name_plural|capfirst }}</label>
-            <a href="#" id="changelist-search-button"><i class="mdi-action-search"></i></a>
-        {% if show_result_count %}
-        <small>{% blocktrans count counter=cl.result_count %}{{ counter }} result{% plural %}{{ counter }} results{% endblocktrans %} (<a href="?{% if cl.is_popup %}_popup=1{% endif %}">{% blocktrans with full_result_count=cl.full_result_count %}{{ full_result_count }} total{% endblocktrans %}</a>)</small>
-        {% endif %}
-        </div>
+        <input type="text" name="{{ search_var }}" value="{{ cl.query }}" id="searchbar"/>
+        <label for="searchbar" class="{% if cl.query %}active{% endif %}">{% trans 'Search' %} {{ cl.opts.verbose_name_plural|capfirst }}</label>
+        <a href="#" id="changelist-search-button"><i class="mdi-action-search"></i></a>
 
         {% for pair in cl.params.items %}
         {% ifnotequal pair.0 search_var %}<input type="hidden" name="{{ pair.0 }}" value="{{ pair.1 }}"/>{% endifnotequal %}


### PR DESCRIPTION
Hi,

I tested a bit some layouts for the filters, and here's my proposition for the admin change list filters.

The filter panel is now horizontal. It can be toggled using a new button at the top right of the list. By default, the filters are hidden if no filter is set and visible if some filters are set.
The button is dark green if some filters are set or light green if no filters are set.

By the way, this PR removes the total results below the search field and puts it at the bottom of the results list.

What do you think ?



![capture d ecran 2016-04-16 17 19 18](https://cloud.githubusercontent.com/assets/1894106/14582555/1769db60-03f8-11e6-88f4-565d21efe300.png)
![capture d ecran 2016-04-16 17 19 23](https://cloud.githubusercontent.com/assets/1894106/14582556/17779ba6-03f8-11e6-84e7-5d5d2997399d.png)

