### PR TITLE
Fix for duplicating drag-target element (when using pjax)

### DIFF
--- a/material/static/material/js/materialize.js
+++ b/material/static/material/js/materialize.js
@@ -2033,8 +2033,11 @@ $(document).ready(function(){
         }
 
         // Add Touch Area
-        var dragTarget = $('<div class="drag-target"></div>');
-        $('body').append(dragTarget);
+        var dragTarget = $('.drag-target');
+        if (!dragTarget.length) {
+            dragTarget = $('<div class="drag-target"></div>');
+            $('body').append(dragTarget);
+        }
 
         if (options.edge == 'left') {
           menu_id.css('transform', 'translateX(-100%)');


### PR DESCRIPTION
At each pjax load the a new drag-target was created and inserted to the dom..

![Screenshot](http://i.imgur.com/OXenlbl.png)
