### PR TITLE
Fixed display of safe readonly fields in TabularInline, StackedInline

### DIFF
--- a/material/admin/templates/material/admin/edit_inline/stacked.html
+++ b/material/admin/templates/material/admin/edit_inline/stacked.html
@@ -28,7 +28,12 @@
                                             <label for="test7">{{ field.field.label|title }}</label>
                                         {% else %}
                                             <label class="active">{{ field.field.label|title }}</label>
-                                            <input disabled value="{{ field.contents }}">
+
+                                            {%if field.contents|escape == field.contents %}
+                                                {{field.contents}}
+                                            {% else %}
+                                                <input disabled value="{{ field.contents }}">
+                                            {% endif %}
                                         {% endif %}
                                     </div>
                                 </div>

--- a/material/admin/templates/material/admin/edit_inline/tabular.html
+++ b/material/admin/templates/material/admin/edit_inline/tabular.html
@@ -28,7 +28,12 @@
                                             <label for="test7">{{ field.field.label|title }}</label>
                                         {% else %}
                                             <label class="active">{{ field.field.label|title }}</label>
-                                            <input disabled value="{{ field.contents }}">
+
+                                            {%if field.contents|escape == field.contents %}
+                                                {{field.contents}}
+                                            {% else %}
+                                                <input disabled value="{{ field.contents }}">
+                                            {% endif %}
                                         {% endif %}
                                     </div>
                                 </div>


### PR DESCRIPTION
I made a small fix to display readonly strings that are marked safe as is in TabularInline and StackedInline.