### PR TITLE
Trailing spaces on include where breaking css imports

### DIFF
--- a/material/templates/material/includes/material_css.html
+++ b/material/templates/material/includes/material_css.html
@@ -1,5 +1,5 @@
 {% load static %}
 <link href="{% static 'material/fonts/material-design-icons/material-icons.css' %}" rel="stylesheet">
 <link href="{% static 'material/css/materialize.css' %}" rel="stylesheet">
-<link href="{% static 'material/css/jquery.datetimepicker.css ' %}" rel="stylesheet">
-<link href="{% static 'material/css/forms.css ' %}" rel="stylesheet">
+<link href="{% static 'material/css/jquery.datetimepicker.css' %}" rel="stylesheet">
+<link href="{% static 'material/css/forms.css' %}" rel="stylesheet">


### PR DESCRIPTION
Super simple one - just removed the spaces in `material_css.html`. Not sure how this hasn't been a problem for everyone else? 

Now you can do: 

```
{% include 'material/includes/material_css.html' %}
```

and it will work