### PR TITLE
Remove whitespace at the end of some links

### DIFF
--- a/material/templates/material/includes/material_css.html
+++ b/material/templates/material/includes/material_css.html
@@ -1,5 +1,5 @@
 {% load static %}
 <link href="{% static 'material/fonts/material-design-icons/material-icons.css' %}" rel="stylesheet">
 <link href="{% static 'material/css/materialize.css' %}" rel="stylesheet">
-<link href="{% static 'material/css/jquery.datetimepicker.css ' %}" rel="stylesheet">
-<link href="{% static 'material/css/forms.css ' %}" rel="stylesheet">
+<link href="{% static 'material/css/jquery.datetimepicker.css' %}" rel="stylesheet">
+<link href="{% static 'material/css/forms.css' %}" rel="stylesheet">


### PR DESCRIPTION
My setup with bare django 1.10 and django-material has the problem with the links
![broken_links](https://cloud.githubusercontent.com/assets/367259/17649784/751d8238-6245-11e6-9b0a-c87e2e123d94.png)
