### PR TITLE
Update admin templates to use all available submit types and save button options

### DIFF
--- a/material/admin/templates/admin/change_form.html
+++ b/material/admin/templates/admin/change_form.html
@@ -19,6 +19,11 @@
     <div class="col s12 m12 l9">
         <form {% if has_file_field %}enctype="multipart/form-data" {% endif %}action="{{ form_url }}" method="post" id="{{ opts.model_name }}_form">
             <div class="card">
+                {% if save_on_top %}{% block submit_buttons_top %}<div class="card-action">
+                    <div class="right-align">
+                        {% submit_row %}
+                    </div>
+                </div>{% endblock %}{% endif %}
                 <div class="card-content">
                     {% csrf_token %}
                     {% if is_popup %}<input type="hidden" name="{{ is_popup_var }}" value="1" />{% endif %}

--- a/material/admin/templates/admin/submit_line.html
+++ b/material/admin/templates/admin/submit_line.html
@@ -5,3 +5,6 @@
 <a href="{% add_preserved_filters delete_url %}" class="deletelink waves-effect waves-light btn red white-text">{% trans "Delete" %}</a>
 {% endif %}
 {% if show_save %}<button type="submit" class="waves-effect waves-light btn white-text">{% trans 'Save' %}</button>{% endif %}
+{% if show_save_as_new %}<input type="submit" class="waves-effect waves-light btn white-text" value="{% trans 'Save as new' %}" name="_saveasnew" />{% endif %}
+{% if show_save_and_add_another %}<input type="submit" class="waves-effect waves-light btn white-text" value="{% trans 'Save and add another' %}" name="_addanother" />{% endif %}
+{% if show_save_and_continue %}<input type="submit" class="waves-effect waves-light btn white-text" value="{% trans 'Save and continue editing' %}" name="_continue" />{% endif %}


### PR DESCRIPTION
The features for show_save_as_new, show_save_and_add_another, save_and_continue and save_on_top  should be exposed through the templates and the admin author should be able to decided whether or not to use them in the admin dashboard.