### PR TITLE
Fixed readonly admin field template bug

### DIFF
--- a/material/admin/templates/material/fields/django_adminreadonlyfield.html
+++ b/material/admin/templates/material/fields/django_adminreadonlyfield.html
@@ -12,7 +12,7 @@
         {% else %}
             <div class="input-field col s12">
                 <label class="active">{{ fieldset_field.field.label|title }}</label>
-                <input disabled value="{{ field.contents }}">
+                <input disabled value="{{ fieldset_field.contents }}">
                 {% if fieldset_field.field.help_text %}
                     <small class="help-block">{{ fieldset_field.field.help_text }}</small>
                 {% endif %}


### PR DESCRIPTION
This branch fixes #187.  The issue was originally caused by a typo https://github.com/viewflow/django-material/commit/04ae12d4066efd3022b68c9535147a4444e39c6b where `fieldset_field.contents` got changed to `field.contents`.  This branch changes that text back.

## Testing
 -[x] Declared `readonly_fields` in ModelAdmin and asserted that fields were correctly populated and disabled
 -[x] Removed fields from `readonly_fields` declaration and asserted that fields were correctly populated and *not* disabled