### PR TITLE
added next parameter to avoid bad redirection at admin

### DIFF
--- a/material/admin/templates/admin/login.html
+++ b/material/admin/templates/admin/login.html
@@ -9,6 +9,7 @@
                 <span class="card-title black-text">{% trans 'Log in' %}</span>
 
                 <form action="{{ app_path }}" method="post" id="login-form">{% csrf_token %}
+                <input type="hidden" name="next" value="{{ next }}" />
                     {% if 'username' in form.fields %}
                     {% form %}
                         {% part form.username prefix %}<i class="material-icons prefix">account_box</i>{% endpart %}


### PR DESCRIPTION
Hello,

I was using the library and found a little bug. If you try to log in at the admin using /admin/login/, instead of (admin/login/?next=/admin/) it will redirect you to the url you define at LOGIN_REDIRECT_URL settings. This is produced because at your admin/login.html you are missing the following line inside the form

`<input type="hidden" name="next" value="{{ next }}" />`

you may see it [here](https://github.com/django/django/blob/master/django/contrib/admin/templates/admin/login.html), line 52.

Django's login looks for the next parameter to redirect, else it will use LOGIN_REDIRECT_URL to get the redirect url.

This little pull request should fix this problem.

Thank you