### PR TITLE
Replace "True/False" with material icons when rendering a boolean column

### DIFF
--- a/material/frontend/views/list.py
+++ b/material/frontend/views/list.py
@@ -14,6 +14,7 @@ from django.core.urlresolvers import reverse
 from django.db.models.query import QuerySet
 from django.forms.forms import pretty_name
 from django.http import JsonResponse
+from django.template.loader import render_to_string
 from django.utils import formats, six, timezone
 from django.utils.decorators import method_decorator
 from django.utils.encoding import force_text
@@ -233,11 +234,18 @@ class DataTableMixin(ContextMixin):
             attr = self.get_data_attr(field_name)
             yield field_name, attr.label
 
+    def _boolean_column(self, value):
+        if value:
+            return render_to_string(template_name='material/icons/true.html')
+        return render_to_string(template_name='material/icons/false.html')
+
     def format_column(self, item, field_name, value):
         if value is None:
             return self.empty_value_display
         elif isinstance(value, datetime.datetime):
             return formats.localize(timezone.template_localtime(value))
+        elif isinstance(value, bool):
+            return self._boolean_column(value)
         elif isinstance(value, (datetime.date, datetime.time)):
             return formats.localize(value)
         elif isinstance(value, six.integer_types + (decimal.Decimal, float)):

--- a/material/frontend/views/list.py
+++ b/material/frontend/views/list.py
@@ -234,18 +234,15 @@ class DataTableMixin(ContextMixin):
             attr = self.get_data_attr(field_name)
             yield field_name, attr.label
 
-    def _boolean_column(self, value):
-        if value:
-            return render_to_string(template_name='material/icons/true.html')
-        return render_to_string(template_name='material/icons/false.html')
-
     def format_column(self, item, field_name, value):
         if value is None:
             return self.empty_value_display
         elif isinstance(value, datetime.datetime):
             return formats.localize(timezone.template_localtime(value))
         elif isinstance(value, bool):
-            return self._boolean_column(value)
+            if value:
+                return render_to_string(template_name='material/icons/true.html')
+            return render_to_string(template_name='material/icons/false.html')
         elif isinstance(value, (datetime.date, datetime.time)):
             return formats.localize(value)
         elif isinstance(value, six.integer_types + (decimal.Decimal, float)):

--- a/material/static/material/css/materialize.frontend.css
+++ b/material/static/material/css/materialize.frontend.css
@@ -211,6 +211,11 @@ table[data-form-control="datatable"] {
     padding-left: 20px; }
   table[data-form-control="datatable"] tbody tr > td:last-child {
     padding-right: 20px; }
+  table[data-form-control="datatable"] tbody tr > td i.material-icons {
+    height: 16px;
+    margin-top: -8px;
+    font-size: 22px;
+    display: block; }
 
 /* ALERTS */
 .toast a {

--- a/material/templates/material/icons/false.html
+++ b/material/templates/material/icons/false.html
@@ -1,0 +1,1 @@
+<i class="material-icons">close</i>

--- a/material/templates/material/icons/true.html
+++ b/material/templates/material/icons/true.html
@@ -1,0 +1,1 @@
+<i class="material-icons">check</i>


### PR DESCRIPTION
This will be used when rendering the Detail layout (#194).

I've put the rendering of the icon in a template (`render_to_string(template_name='material/icons/true.html')`) instead returning the html string but I don't know if its the proper way to do this.