### PR TITLE
Fix regex for Django 1.11

### DIFF
--- a/material/admin/templatetags/material_admin.py
+++ b/material/admin/templatetags/material_admin.py
@@ -24,7 +24,7 @@ from ..base import AdminReadonlyField, Inline
 register = Library()
 
 
-CL_VALUE_RE = re.compile('value="(.*)\"')
+CL_VALUE_RE = re.compile('value="(.*)" class')
 
 
 def get_admin_site():


### PR DESCRIPTION
This needs testing with older versions

It's perfectly working so far with Django 1.11 and Python 3.6

Thanks @hairychris for the work !