### PR TITLE
Multiple admin modules support #148

### DIFF
--- a/material/admin/templates/admin/base.html
+++ b/material/admin/templates/admin/base.html
@@ -55,7 +55,7 @@
                 {% if site_url %}
                     {% block back_link %}<li class="no-padding"><a class="collapsible-header" href="{{ site_url }}"><i class="material-icons">arrow_back</i>{% trans 'View site' %}</a></li>{% endblock %}
                 {% endif %}
-                {% get_app_list request as app_list %}
+                {% get_app_list app_list as app_list %}
                 {% for app in app_list %}
                 <li {% if app.active %}class="active"{% endif %}>
                     <ul class="collapsible collapsible-accordion">

--- a/material/admin/templates/admin/index.html
+++ b/material/admin/templates/admin/index.html
@@ -8,7 +8,7 @@
 {% block content %}
 <div class="row">
     <div class="app-list">
-        {% get_app_list request as app_list %}
+        {% get_app_list app_list as app_list %}
         {% for app in app_list %}
         <div class="app">
             <div class="card">

--- a/material/admin/templatetags/material_admin.py
+++ b/material/admin/templatetags/material_admin.py
@@ -44,7 +44,11 @@ site = get_admin_site()
 
 @register.simple_tag
 def get_app_list(apps_list):
-    """Set icons for app and models."""
+    """
+    Set icons for app and models.
+
+    `app_list` already in context.
+    """
     app_list = []
     for app in apps_list:
         app_label = app['app_label']


### PR DESCRIPTION
This rewrite, fix problem with custom admin.
`app_list` variable already in context, is not necessary fetch installed app or check permissions.

#148 
@sysint64 Maybe this changes can help you.