### PR TITLE
Fix LICENSE in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include LICENSE
+include LICENSE.txt
 include MANIFEST.in
 include README.rst
 recursive-include material/templates *


### PR DESCRIPTION
The `MANIFEST.in` points to `LICENSE` instead of `LICENSE.txt` so the license file is not included in the source distribution. 