### PR TITLE
FileField fix multiple files

### DIFF
--- a/material/templates/material/fields/django_fileinput.html
+++ b/material/templates/material/fields/django_fileinput.html
@@ -6,7 +6,7 @@
    {% endattrs %}>
         <div class="btn">
             {% part field prefix %}<span>{% trans 'File' %}</span>{% endpart %}
-            <input type="file" name="{{ bound_field.html_name }}"/>
+            <input type="file" name="{{ bound_field.html_name }}" {% if field.widget.attrs.multiple %}multiple{% endif%}/>
         </div>
         {% part field suffix %}{% endpart %}{% part field control %}<div class="file-path-wrapper">
             <input{% attrs bound_field 'widget' default field.widget.attrs %}


### PR DESCRIPTION
Hi there! Thanks for your great library)
Recently I needed custom multiple file upload field in form. I find out that all widget attributes go to file path wrapper, but not to button itself. So I decided to at least add this attribute to button and came out with this tiny pull request.
Field from my ModelForm:
```
...
attachments = forms.FileField(required=False, widget=forms.ClearableFileInput(attrs={'multiple': True}))
...
```