### PR TITLE
return the actual related object instead the id

### DIFF
--- a/material/frontend/templates/material/frontend/views/detail.html
+++ b/material/frontend/templates/material/frontend/views/detail.html
@@ -17,7 +17,11 @@
                 {% for field_name, value in object_data %}
                 <tr>
                     <th>{{ field_name }}</th>
+                    {% if value.get_absolute_url %}
+                    <td><a href="{{ value.get_absolute_url }}">{{ value }}</a></td>
+                    {% else %}
                     <td>{{ value }}</td>
+                    {% endif %}
                 </tr>
                 {% endfor %}
             </table>

--- a/material/frontend/views/detail.py
+++ b/material/frontend/views/detail.py
@@ -24,11 +24,11 @@ class DetailModelView(generic.DetailView):
             elif field.auto_created:
                 continue
             else:
-                choice_display_attr = "get_{}_display".format(field.get_attname())
+                choice_display_attr = "get_{}_display".format(field.name)
             if hasattr(self.object, choice_display_attr):
                 value = getattr(self.object, choice_display_attr)()
             else:
-                value = getattr(self.object, field.get_attname())
+                value = getattr(self.object, field.name)
 
             if value is not None:
                 yield (field.verbose_name.title(), value)


### PR DESCRIPTION
if the field is a `ForeignKey`, `field.get_attname()` return the name of the column instead of the actual field (ie, for a fk named `medio`, it returns `"medio_id"`). Then, the `pk` of the related object is returned instead of the actual object, and it looks like this in the detail view. 

![captura de pantalla de 2017-07-21 17-24-43](https://user-images.githubusercontent.com/2355719/28481534-b854a0ec-6e3b-11e7-874c-7fb91b564642.png)

With this change the object is returned, thus its `__str__` is used to display it.  

![captura de pantalla de 2017-07-21 17-24-13](https://user-images.githubusercontent.com/2355719/28481550-c56fb5dc-6e3b-11e7-89b7-106f5c4a9677.png)




