### PR TITLE
error with 'photo' attribute has no file associated with it.

### DIFF
--- a/material/admin/templates/admin/base.html
+++ b/material/admin/templates/admin/base.html
@@ -40,7 +40,7 @@
                     <div class="userView">
                         <img class="background" src="{% static 'material/imgs/sidenav.svg' %}">
                         {% block userphoto %}
-                        {% if user.photo.url %}
+                        {% if user.photo %}
                         <a href="#"><img class="circle" src="{{ user.photo.url }}"></a>
                         {% else %}
                         <a href="#"><img class="circle" src="{% static 'material/imgs/user.png' %}"></a>


### PR DESCRIPTION
There is an error in the admin of django when there is no photo associated with it, since it tries to access the value of the url of the image but since it has no fault, if we leave only user.photo does not release the error since it does not try to access nothing