### PR TITLE
Fix boolean attribute value

### DIFF
--- a/material/templates/material/fields/django_selectmultiple.html
+++ b/material/templates/material/fields/django_selectmultiple.html
@@ -1,7 +1,7 @@
 {% load i18n l10n material_form material_form_internal %}
 
 {% render bound_field template='fields/django_select.html' %}
-    {% attr field 'widget' multiple %}True{% endattr %}
+    {% attr field 'widget' multiple %}multiple{% endattr %}
     {% attr field 'group' class append %}multiselect{% endattr %}
     {% part field options %}
         {% if not field|have_default_choice %}<option value="" disabled>{% trans "Choose your option" %}</option>{% endif %}{% for group, items in bound_field|select_options %}{% if group %}<optgroup label="{{ group }}">{% endif %}{% for choice, value, selected in items %}

--- a/material/templatetags/material_form.py
+++ b/material/templatetags/material_form.py
@@ -304,7 +304,7 @@ class WidgetAttrNode(Node):
 
         {% attr form.email 'widget' 'data-validate' %}email{% endattr %}
         {% attr form.email 'widget' 'class' append %}green{%  endattr %}
-        {% attr form.email 'widget' 'required' %}True{%  endattr %}
+        {% attr form.email 'widget' 'required' %}required{%  endattr %}
 
     """
 


### PR DESCRIPTION
Currently the boolean attribute `multiple` of a select element is rendered incorrectly as follows:

`<select multiple="True">..</select>`

`"True"` is not a valid value for a [boolean attribute](https://stackoverflow.com/questions/4139786/what-does-it-mean-in-html-5-when-an-attribute-is-a-boolean-attribute#answer-4140263). With this pull request I've converted it to the correct value `"multiple"`. Another options would have been to set it to empty as the value `""` is also valid.