### PR TITLE
Change `overflow-y: scroll` to `overflow-y: auto` to fix shaking of m…

### DIFF
--- a/material/static/material/css/materialize.frontend.css
+++ b/material/static/material/css/materialize.frontend.css
@@ -70,7 +70,7 @@ th {
 /* LAYOUT */
 @media only screen and (min-width: 993px) {
   html {
-    overflow-y: scroll; }
+    overflow-y: auto; }
   main, footer {
     margin-left: 300px; }
   nav {


### PR DESCRIPTION
…aterialbox on large screens.

When there is a vertical scrollbar without any content (ie. not scrollable), materialbox (media) 'shakes' when opened. It's enough to simply make overflow-y as auto to fix this (so there is no scrollbar when there are enough items to fit on a screen).