### PR TITLE
Handle disabled input fields

### DIFF
--- a/material/templates/material/fields/django_input.html
+++ b/material/templates/material/fields/django_input.html
@@ -11,6 +11,7 @@
             name="{{ bound_field.html_name }}"
             type="{{ field.widget.input_type }}"
             {% if bound_field.errors %}class="invalid"{% endif %}
+            {% if field.disabled %}disabled{% endif %}
             {% if bound_field.value != None %}value="{{ bound_field.value|unlocalize }}"{% endif %}
         {% endattrs %}>{% endpart %}
         {% part field label %}

--- a/tests/test_widget_textinput.py
+++ b/tests/test_widget_textinput.py
@@ -13,6 +13,14 @@ class TextInputForm(forms.Form):
         widget=forms.TextInput(attrs={'data-test': 'Test Attr'}))
 
 
+class DisabledTextInputForm(forms.Form):
+    test_field = forms.CharField(
+        min_length=5,
+        max_length=20,
+        disabled=True,
+        widget=forms.TextInput(attrs={'data-test': 'Test Attr'}))
+
+
 @override_settings(ROOT_URLCONF=__name__)
 class Test(WebTest):
     default_form = TextInputForm
@@ -139,5 +147,12 @@ class Test(WebTest):
              {% part form.test_field  errors%}<div class="errors"><small class="error">My Error</small></div>{% endpart %}
         {% endform %}
     '''
+
+    def test_disabled_field(self):
+        page = self.app.get(self.test_disabled_field.url)
+
+        self.assertIn('disabled', page.body.decode('utf-8'))
+
+    test_disabled_field.form = DisabledTextInputForm
 
 urlpatterns = build_test_urls(Test)


### PR DESCRIPTION
Since Django 1.9 a form field can be declared as disabled:

https://docs.djangoproject.com/en/dev/ref/forms/fields/#disabled

However these are not rendered as disabled by django-material. This patch fixes it for input fields.