### PR TITLE
Make non field errors easier to customize

### DIFF
--- a/material/templates/material/form.html
+++ b/material/templates/material/form.html
@@ -1,12 +1,6 @@
 {% load material_form material_form_internal %}
 {% part form %}
-    {% if form.non_field_errors%}
-    <div>
-        {% for error in form.non_field_errors %}
-        <small class="error">{{ error }}</small>
-        {% endfor %}
-    </div>
-    {% endif %}
+    {% include "material/non_field_errors.html" %}
     {% part form hidden %}{% for hidden in form.hidden_fields %}
             {{ hidden }}
     {% endfor %}{% endpart %}

--- a/material/templates/material/non_field_errors.html
+++ b/material/templates/material/non_field_errors.html
@@ -1,0 +1,7 @@
+{% if form.non_field_errors %}
+    <div>
+        {% for error in form.non_field_errors %}
+        <small class="error">{{ error }}</small>
+        {% endfor %}
+    </div>
+{% endif %}


### PR DESCRIPTION
I added this part to make it easier to customize error messages generated by `django-material` without the need to change the whole template code of `form.html`.