### PR TITLE
docs: Fix simple typo, extenal -> external

### DIFF
--- a/material/frontend/views/list.py
+++ b/material/frontend/views/list.py
@@ -95,7 +95,7 @@ class ModelAttr(object):
 
 
 class DataSourceAttr(object):
-    """Retrieve attribute value from extenal data source.
+    """Retrieve attribute value from external data source.
 
     Data source attribute could be a property or callable.
 


### PR DESCRIPTION
There is a small typo in material/frontend/views/list.py.

Should read `external` rather than `extenal`.

