### PR TITLE
Update `DataTableMixin` to handle ordering

### DIFF
--- a/material/frontend/views/list.py
+++ b/material/frontend/views/list.py
@@ -287,7 +287,7 @@ class DataTableMixin(ContextMixin):
 
                 try:
                     order = self.get_list_display()[int(column_num)]
-                    if column_dir == 'asc':
+                    if column_dir == 'desc':
                         order = '-' + order
                 except (IndexError, TypeError):
                     """ Skip """


### PR DESCRIPTION
Dear all,

I think a line in `list.py` should be changed as proposed. The documentation in https://docs.djangoproject.com/en/3.1/ref/models/querysets/#django.db.models.query.QuerySet.order_by indicates that "-" should be used for a descending order, not ascending.

Without this change, the rows in `DataTable` objects are sorted in the opposite direction.

Please feel free to accept or decline the PR as you see fit.