### PR TITLE
fix unhandled Exception on TurboLinksMiddleware 

### DIFF
--- a/material/frontend/middleware.py
+++ b/material/frontend/middleware.py
@@ -45,7 +45,7 @@ class TurbolinksMiddleware(object):
     def __call__(self, request):
         response = self.get_response(request)
 
-        if isinstance(response,Exception)
+        if isinstance(response,Exception):
             raise response
 
         is_turbolinks = request.META.get('HTTP_TURBOLINKS_REFERRER')

--- a/material/frontend/middleware.py
+++ b/material/frontend/middleware.py
@@ -45,6 +45,9 @@ class TurbolinksMiddleware(object):
     def __call__(self, request):
         response = self.get_response(request)
 
+        if isinstance(response,Exception)
+            raise response
+
         is_turbolinks = request.META.get('HTTP_TURBOLINKS_REFERRER')
         is_response_redirect = response.has_header('Location')
 


### PR DESCRIPTION
If get_response() is an exception in material.frontend.middleware.TurboLinksMiddleware, the following Django error is thrown:
`AttributeError: 'NameError' object has no attribute 'has_header'`

 I suspect SmoothNavigationMiddleware would also have the same issue, but I haven't experienced it.