### PR TITLE
docs: Fix a few typos

### DIFF
--- a/material/frontend/views/detail.py
+++ b/material/frontend/views/detail.py
@@ -63,7 +63,7 @@ class DetailModelView(generic.DetailView):
         return self.has_change_permission(request, obj=obj)
 
     def has_change_permission(self, request, obj):
-        """Object chane permission check.
+        """Object change permission check.
 
         If view had a `viewset`, the `viewset.has_change_permission` used.
 

--- a/material/static/material/js/jquery.dataTables.js
+++ b/material/static/material/js/jquery.dataTables.js
@@ -4346,7 +4346,7 @@
 	 *  @param {int} iColumn column to filter
 	 *  @param {bool} bRegex treat search string as a regular expression or not
 	 *  @param {bool} bSmart use smart filtering or not
-	 *  @param {bool} bCaseInsensitive Do case insenstive matching or not
+	 *  @param {bool} bCaseInsensitive Do case insensitive matching or not
 	 *  @memberof DataTable#oApi
 	 */
 	function _fnFilterColumn ( settings, searchStr, colIdx, regex, smart, caseInsensitive )
@@ -4379,7 +4379,7 @@
 	 *  @param {int} force optional - force a research of the master array (1) or not (undefined or 0)
 	 *  @param {bool} regex treat as a regular expression or not
 	 *  @param {bool} smart perform smart filtering or not
-	 *  @param {bool} caseInsensitive Do case insenstive matching or not
+	 *  @param {bool} caseInsensitive Do case insensitive matching or not
 	 *  @memberof DataTable#oApi
 	 */
 	function _fnFilter( settings, input, force, regex, smart, caseInsensitive )
@@ -12418,7 +12418,7 @@
 		 *          "data": function ( source, type, val ) {
 		 *            if (type === 'set') {
 		 *              source.price = val;
-		 *              // Store the computed dislay and filter values for efficiency
+		 *              // Store the computed display and filter values for efficiency
 		 *              source.price_display = val=="" ? "" : "$"+numberFormat(val);
 		 *              source.price_filter  = val=="" ? "" : "$"+numberFormat(val)+" "+val;
 		 *              return;

--- a/material/static/material/js/jquery.datetimepicker.full.js
+++ b/material/static/material/js/jquery.datetimepicker.full.js
@@ -2898,7 +2898,7 @@ var datetimepickerFactory = function ($) {
     }
 
     function shouldAdjustOldDeltas(orgEvent, absDelta) {
-        // If this is an older event and the delta is divisable by 120,
+        // If this is an older event and the delta is divisible by 120,
         // then we are assuming that the browser is treating this as an
         // older mouse wheel event and that we should divide the deltas
         // by 40 to try and get a more usable deltaFactor.

--- a/material/static/material/js/materialize.js
+++ b/material/static/material/js/materialize.js
@@ -5518,7 +5518,7 @@ $jscomp.polyfill = function (e, r, p, m) {
       _this31.isFixed = _this31.el.classList.contains('sidenav-fixed');
 
       /**
-       * Describes if Sidenav is being draggeed
+       * Describes if Sidenav is being dragged
        * @type {Boolean}
        */
       _this31.isDragged = false;


### PR DESCRIPTION
There are small typos in:
- material/frontend/views/detail.py
- material/static/material/js/jquery.dataTables.js
- material/static/material/js/jquery.datetimepicker.full.js
- material/static/material/js/materialize.js

Fixes:
- Should read `insensitive` rather than `insenstive`.
- Should read `dragged` rather than `draggeed`.
- Should read `divisible` rather than `divisable`.
- Should read `display` rather than `dislay`.
- Should read `change` rather than `chane`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md