### PR TITLE
Fix typo compoments to components

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -5,7 +5,7 @@
 - [X] unpoly links on index page
 - [ ] overal re-structure using Site and Application
 
-## Compoments
+## Components
 
 - [X] Add esbild esbuild main.js --bundle --outfile=bundle.js --format=iife --global-name=MyLib --minify
 - [ ] use {{ debug }} to add min or not minified fiels

--- a/demo/urls.py
+++ b/demo/urls.py
@@ -7,7 +7,7 @@ from demo.crud.atlas.views import list_view, cursor_list_view
 import debug_toolbar
 
 cotton = Application(
-    title="Compoments",
+    title="Components",
     app_name="html",
     icon="layers",
     urlpatterns=[


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected a typographical error, changing "Compoments" to "Components" in documentation and user-facing titles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->